### PR TITLE
move remote check into site transient

### DIFF
--- a/assets/js/themes-wp-rollback.js
+++ b/assets/js/themes-wp-rollback.js
@@ -14,8 +14,8 @@ jQuery.noConflict();
 		themes = wp.themes = wp.themes || {};
 		themes.data = _wpThemeSettings;
 
-		// on page load if route renders modal
-		if( $('.theme-browser.rendered').length > 0 ) {
+		// on page load if route renders
+		if( $('.theme-overlay .theme-overlay').length > 0 ) {
 			var modal_theme = wpr_get_parameter_by_name( 'theme' );
 			wpr_theme_rollback( modal_theme );
 		}

--- a/assets/js/themes-wp-rollback.js
+++ b/assets/js/themes-wp-rollback.js
@@ -14,11 +14,17 @@ jQuery.noConflict();
 		themes = wp.themes = wp.themes || {};
 		themes.data = _wpThemeSettings;
 
+		// on page load if route renders modal
+		if( $('.theme-browser.rendered').length > 0 ) {
+			var modal_theme = wpr_get_parameter_by_name( 'theme' );
+			wpr_theme_rollback( modal_theme );
+		}
+
 		//On clicking a theme template
 		$( themes.template, 'button.left', 'button.right' ).on( 'click', function ( e ) {
 
 			//get theme name that was clicked
-			var clicked_theme = wpr_get_parameter_by_name( 'theme' );
+			var clicked_theme = wpr_get_parameter_from_focused_theme();
 
 			//check that rollback button hasn't been placed
 			if ( is_rollback_btn_there() ) {
@@ -81,31 +87,18 @@ jQuery.noConflict();
 				action: 'is_wordpress_theme',
 				theme : theme
 			};
-			$.post( ajaxurl, data, function ( response ) {
 
-				//console.log( response );
+			var theme_data = wpr_get_theme_data( theme );
 
-				//this theme is WordPress
-				if ( response === 'wp' ) {
+			console.log( theme_data );
 
-					//Get the data for this theme
-					var theme_data = wpr_get_theme_data( theme );
-
-
-					//Form the rollback uri
-					var rollback_btn_html = '<a href="' + encodeURI( 'index.php?page=wp-rollback&type=theme&theme=' + theme + '&current_version=' + theme_data.version + '&rollback_name=' + theme_data.name + '' ) + '" style="position:absolute;right: 80px; bottom: 5px;" class="button wpr-theme-rollback">' + wpr_vars.text_rollback_label + '</a>';
-
-					$( '.theme-actions' ).append( rollback_btn_html );
-
-				} else {
-					//Can't roll back this theme, display the
-					$( '.theme-actions' ).append( '<span class="no-rollback" style="position: absolute;left: 23px;bottom: 16px;font-size: 12px;font-style: italic;color: rgb(181, 181, 181);">' + wpr_vars.text_not_rollbackable + '</span>' );
-
-				}
-
-				return false;
-
-			} );
+			if( theme_data.hasRollback ) {
+				var rollback_btn_html = '<a href="' + encodeURI( 'index.php?page=wp-rollback&type=theme&theme=' + theme + '&current_version=' + theme_data.version + '&rollback_name=' + theme_data.name + '' ) + '" style="position:absolute;right: 80px; bottom: 5px;" class="button wpr-theme-rollback">' + wpr_vars.text_rollback_label + '</a>';
+				$( '.theme-actions' ).append( rollback_btn_html );
+			}else{
+				//Can't roll back this theme, display the
+				$( '.theme-actions' ).append( '<span class="no-rollback" style="position: absolute;left: 23px;bottom: 16px;font-size: 12px;font-style: italic;color: rgb(181, 181, 181);">' + wpr_vars.text_not_rollbackable + '</span>' );
+			}
 
 		}
 
@@ -141,6 +134,12 @@ jQuery.noConflict();
 			var regex = new RegExp( "[\\?&]" + name + "=([^&#]*)" ),
 				results = regex.exec( location.search );
 			return results === null ? "" : decodeURIComponent( results[1].replace( /\+/g, " " ) );
+		}
+
+		function wpr_get_parameter_from_focused_theme() {
+			var focussedTheme = wp.themes.focusedTheme;
+			name = $( focussedTheme ).find('.theme-name').attr('id').replace('-name','');
+			return name;
 		}
 
 

--- a/includes/rollback-action.php
+++ b/includes/rollback-action.php
@@ -26,10 +26,12 @@ if ( isset( $_GET['theme_file'] ) ) {
 
 	$upgrader->rollback( $_GET['theme_file'] );
 
-} else {
+} elseif ( isset( $_GET['plugin_file'] ) ) {
 	//This is a plugin rollback
 	$upgrader = new WP_Rollback_Plugin_Upgrader( new Plugin_Upgrader_Skin( compact( 'title', 'nonce', 'url', 'plugin', 'version' ) ) );
 
 	$upgrader->rollback( $this->plugin_file );
+} else {
+	_e( 'This rollback request is missing proper query string. Please contact support.', 'wpr' );
 }
 

--- a/includes/rollback-menu.php
+++ b/includes/rollback-menu.php
@@ -28,13 +28,13 @@ $plugins         = get_plugins();
 
 	<?php if ( isset( $args['plugin_file'] ) && in_array( $args['plugin_file'], array_keys( $plugins ) ) ) {
 		$versions = WP_Rollback()->versions_select( 'plugin' );
-	} elseif ( $theme_rollback == true ) {
+	} elseif ( $theme_rollback == true && isset( $_GET['theme_file'] ) ) {
 		//theme rollback: set up our theme vars
-		$svn_tags = WP_Rollback()->get_svn_tags( 'theme', $_GET['theme'] );
+		$svn_tags = WP_Rollback()->get_svn_tags( 'theme', $_GET['theme_file'] );
 		$this->set_svn_versions_data( $svn_tags );
 		$this->current_version = $_GET['current_version'];
-		$versions = WP_Rollback()->versions_select( 'theme' );
-		
+		$versions              = WP_Rollback()->versions_select( 'theme' );
+
 	} else {
 		//Fallback check
 		wp_die( 'Oh no! We\'re missing required rollback query strings. Please contact support so we can check this bug out and squash it!', 'wpr' );
@@ -70,7 +70,7 @@ $plugins         = get_plugins();
 		if ( $plugin_rollback == true ) { ?>
 			<input type="hidden" name="plugin_file" value="<?php echo $args['plugin_file']; ?>">
 		<?php } else { ?>
-			<input type="hidden" name="theme_file" value="<?php echo $_GET['theme']; ?>">
+			<input type="hidden" name="theme_file" value="<?php echo $_GET['theme_file']; ?>">
 		<?php } ?>
 		<input type="hidden" name="rollback_name" value="<?php echo $args['rollback_name']; ?>">
 		<input type="hidden" name="installed_version" value="<?php echo $args['current_version']; ?>">

--- a/wp-rollback.php
+++ b/wp-rollback.php
@@ -578,3 +578,95 @@ function WP_Rollback() {
 
 // Get WP Rollback Running
 WP_Rollback();
+
+
+function wpr_rollback_themes() {
+
+	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
+
+	if ( defined( 'WP_INSTALLING' ) )
+		return false;
+
+	$expiration = 12 * HOUR_IN_SECONDS;
+	$installed_themes = wp_get_themes();
+
+	$last_update = get_site_transient( 'update_themes' );
+	if ( ! is_object($last_update) )
+		set_site_transient( 'rollback_themes', time(), $expiration );
+
+	$themes = $checked = $request = array();
+
+	// Put slug of current theme into request.
+	$request['active'] = get_option( 'stylesheet' );
+
+	foreach ( $installed_themes as $theme ) {
+		$checked[ $theme->get_stylesheet() ] = $theme->get('Version');
+
+		$themes[ $theme->get_stylesheet() ] = array(
+			'Name'       => $theme->get('Name'),
+			'Title'      => $theme->get('Name'),
+			'Version'    => '0.0.0.0.0.0',
+			'Author'     => $theme->get('Author'),
+			'Author URI' => $theme->get('AuthorURI'),
+			'Template'   => $theme->get_template(),
+			'Stylesheet' => $theme->get_stylesheet(),
+		);
+	}
+
+	$request['themes'] = $themes;
+
+	$timeout = 3 + (int) ( count( $themes ) / 10 );
+
+	$options = array(
+		'timeout' => $timeout,
+		'body' => array(
+			'themes'       => wp_json_encode( $request ),
+		),
+		'user-agent'	=> 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' )
+	);
+
+	$url = $http_url = 'http://api.wordpress.org/themes/update-check/1.1/';
+	if ( $ssl = wp_http_supports( array( 'ssl' ) ) )
+		$url = set_url_scheme( $url, 'https' );
+
+	$raw_response = wp_remote_post( $url, $options );
+	if ( $ssl && is_wp_error( $raw_response ) ) {
+		trigger_error( __( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/">support forums</a>.' ) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ), headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE );
+		$raw_response = wp_remote_post( $http_url, $options );
+	}
+
+	set_site_transient( 'rollback_themes', time(), $expiration );
+
+	if ( is_wp_error( $raw_response ) || 200 != wp_remote_retrieve_response_code( $raw_response ) )
+		return false;
+
+	$new_update = new stdClass;
+	$new_update->last_checked = time();
+	$new_update->checked = $checked;
+
+	$response = json_decode( wp_remote_retrieve_body( $raw_response ), true );
+
+	if ( is_array( $response ) )
+		$new_update->response = $response['themes'];
+
+	set_site_transient( 'rollback_themes', $new_update );
+}
+
+
+add_action( 'set_site_transient_update_themes', 'wpr_rollback_themes' );
+
+function wpr_prepare_themes_js( $prepared_themes ) {
+	$themes = array();
+	$wp_themes = get_site_transient( 'rollback_themes' );
+	$rollbacks = $wp_themes->response;
+
+	foreach ($prepared_themes as $key => $value) {
+		$themes[$key] = $prepared_themes[$key];
+		$themes[$key]['hasRollback'] = isset( $rollbacks[ $key ] );
+	}
+
+	return $themes;
+}
+
+
+add_filter( 'wp_prepare_themes_for_js', 'wpr_prepare_themes_js' );


### PR DESCRIPTION
wpr_rollback_themes - runs directly after theme update check and is cached for 12 hours. The returned data is a list of wp.org themes.

wpr_prepare_themes_js - modifies the initial js output used by wp.themes adding a hasRollback variable so our button has something to attach to.

wpr_get_parameter_from_focused_theme - uses wp.themes.focusedTheme. I didn't remove your original function because wp.themes.focusedTheme is not set on initial page load even if the modal is visible.