### PR TITLE
Issue/7

### DIFF
--- a/assets/css/wp-rollback.css
+++ b/assets/css/wp-rollback.css
@@ -102,3 +102,17 @@
 	font-size: 18px;
 	margin-top: 0;
 }
+
+.wpr-changelog-link {
+	font-size:11px;
+	font-style: italic;
+	display: none;
+	opacity:0;
+	line-height: 1;
+
+}
+
+.wpr-versions-wrap label:hover .wpr-changelog-link {
+	display: inline-block;
+	opacity:0.8;
+}

--- a/assets/css/wp-rollback.css
+++ b/assets/css/wp-rollback.css
@@ -123,7 +123,7 @@
 	text-decoration: underline;
 }
 .wpr-version-li:hover .wpr-changelog-link {
-	opacity: 0.8;
+	opacity: 0.75;
 }
 /* Hide full changelog */
 .wpr-changelog, .wpr-hidden-changelog {
@@ -137,4 +137,8 @@
 	margin: 20px 0;
 	max-height: 350px;
 	overflow-y: auto;
+}
+
+.wpr-no-changelog-message {
+	margin-bottom:0;
 }

--- a/assets/css/wp-rollback.css
+++ b/assets/css/wp-rollback.css
@@ -104,15 +104,30 @@
 }
 
 .wpr-changelog-link {
-	font-size:11px;
+	font-size: 11px;
 	font-style: italic;
 	display: none;
-	opacity:0;
+	opacity: 0;
 	line-height: 1;
 
 }
 
 .wpr-versions-wrap label:hover .wpr-changelog-link {
 	display: inline-block;
-	opacity:0.8;
+	opacity: 0.8;
+}
+
+
+/* Hide full changelog */
+.wpr-changelog {
+	display: none;
+}
+
+/* The changelog that appears when loading via AJAX */
+.wpr-changelog-entry {
+	padding: 6px 25px;
+	background: #FFF;
+	margin: 20px 0;
+	max-height: 350px;
+	overflow-y: auto;
 }

--- a/assets/css/wp-rollback.css
+++ b/assets/css/wp-rollback.css
@@ -28,23 +28,10 @@
 	font-weight: 600;
 }
 
-.rollback-form {
-
-}
-
 .wpr-versions-wrap {
 	padding-left: 20px;
 }
 
-.rollback-form label {
-	display: block;
-	padding: 8px 0;
-	font-size: 16px;
-}
-
-.rollback-form label input {
-	margin-right: 5px;
-}
 
 .wpr-submit-wrap {
 	margin: 25px 0 0;
@@ -74,12 +61,24 @@
 	margin-right: 5px !important;
 }
 
-/* Modal */
+/* List */
 
-#wpr-modal-confirm {
-
+.wpr-version-li {
+	clear: left;
+	padding: 8px 0;
+	overflow: hidden;
+}
+.wpr-version-li label {
+	float:left;
+	font-size: 16px;
 }
 
+.wpr-version-li label input {
+	margin-right: 5px;
+}
+
+
+/* Modal */
 #wpr-modal-confirm .button-primary {
 	margin-right: 5px;
 }
@@ -103,29 +102,37 @@
 	margin-top: 0;
 }
 
+
+/* Changelog link */
 .wpr-changelog-link {
+	float: left;
+	margin: 4px 0 0 12px;
 	font-size: 11px;
 	font-style: italic;
-	display: none;
 	opacity: 0;
 	line-height: 1;
-
-}
-
-.wpr-versions-wrap label:hover .wpr-changelog-link {
+	transition: .15s ease-in-out;
+	-moz-transition: .15s ease-in-out;
+	-webkit-transition: .15s ease-in-out;
 	display: inline-block;
+	outline:none;
+	box-shadow:none !important;
+	text-decoration: none;
+}
+.wpr-changelog-link:hover {
+	text-decoration: underline;
+}
+.wpr-version-li:hover .wpr-changelog-link {
 	opacity: 0.8;
 }
-
-
 /* Hide full changelog */
-.wpr-changelog {
+.wpr-changelog, .wpr-hidden-changelog {
 	display: none;
 }
 
 /* The changelog that appears when loading via AJAX */
 .wpr-changelog-entry {
-	padding: 6px 25px;
+	padding: 6px 25px 18px;
 	background: #FFF;
 	margin: 20px 0;
 	max-height: 350px;

--- a/assets/js/wp-rollback.js
+++ b/assets/js/wp-rollback.js
@@ -117,7 +117,7 @@ jQuery.noConflict();
 
 			// If no changelog found, show message.
 			if ( ! $( '.wpr-changelog-entry' ).html().length ) {
-				$( '.wpr-changelog-entry' ).append( '<p>' + wpr_vars.text_no_changelog_found + '</p>' );
+				$( '.wpr-changelog-entry' ).append( '<p class="wpr-no-changelog-message">' + wpr_vars.text_no_changelog_found + '</p>' );
 			}
 
 		}

--- a/assets/js/wp-rollback.js
+++ b/assets/js/wp-rollback.js
@@ -17,7 +17,9 @@ jQuery.noConflict();
 		var form_labels = $( 'label', form.get( 0 ) );
 		var form_submit_btn = $( '.magnific-popup' );
 
-		// On Element Click
+		/**
+		 * On version click
+		 */
 		form_labels.on( 'click', function() {
 
 			// add a selected class
@@ -27,6 +29,44 @@ jQuery.noConflict();
 
 			// ensure the radio button always gets clicked
 			$( this ).find( 'input' ).prop( 'checked', true );
+
+		} );
+
+		/**
+		 * On changelog click
+		 */
+		$( '.wpr-changelog-link' ).on( 'click', function( e ) {
+
+			e.preventDefault();
+			var changelog_container = $( '.wpr-changelog' );
+
+			$.post(
+				ajaxurl,
+				{
+					'action': 'wpr_check_changelog',
+					'data': '1.8.9'
+				}, function( response ) {
+
+					$( changelog_container ).append( $.parseHTML( response ) );
+
+					var changelog_headings = $( changelog_container ).find( 'h4' );
+					var changelog_entry = '';
+
+					$( changelog_headings ).each( function( index, value ) {
+
+						var raw_val = $( value ).text();
+
+						if ( raw_val.indexOf( '1.8.11' ) >= 0 ) {
+							changelog_entry = value;
+							changelog_entry.append( $( value ).next( 'ul' ).text() );
+						}
+
+					} );
+
+					console.log( changelog_entry );
+
+				}
+			);
 
 		} );
 

--- a/assets/js/wp-rollback.js
+++ b/assets/js/wp-rollback.js
@@ -40,10 +40,13 @@ jQuery.noConflict();
 			e.preventDefault();
 
 			var changelog_container = $( '.wpr-changelog' );
-			var changelog_placement = $( this ).parent( 'label' );
+			var changelog_placement = $( this ).parent( 'li' );
 			var version = $( this ).data( 'version' );
 
-			// If changelog already fetched.
+			// Ensure all change log links are visible.
+			$('.wpr-changelog-link').removeClass('wpr-hidden-changelog')
+
+			// If changelog was already fetched, use that data.
 			if ( changelog_container.html().length ) {
 				wpr_append_changelog_entry( changelog_placement, version );
 				return false;
@@ -78,6 +81,9 @@ jQuery.noConflict();
 
 			// Remove old entry.
 			$( '.wpr-changelog-entry' ).remove();
+
+			// Hide this change log link.
+			$(placement).find('.wpr-changelog-link').addClass('wpr-hidden-changelog');
 
 			// Append a new one.
 			$( placement ).after( '<div class="wpr-changelog-entry"></div>' );

--- a/includes/rollback-menu.php
+++ b/includes/rollback-menu.php
@@ -19,27 +19,28 @@ $plugins         = get_plugins();
 	<div class="wpr-content-wrap">
 
 		<h1>
-			<img src="<?php echo WP_ROLLBACK_PLUGIN_URL; ?>/assets/images/wprb-icon-final.svg" onerror="this.onerror=null; this.src='<?php echo WP_ROLLBACK_PLUGIN_URL; ?>/assets/images/wprb-logo.png'"><?php _e( 'WP Rollback', 'wp-rollback' ); ?>
+			<img src="<?php echo WP_ROLLBACK_PLUGIN_URL; ?>/assets/images/wprb-icon-final.svg"
+			     onerror="this.onerror=null; this.src='<?php echo WP_ROLLBACK_PLUGIN_URL; ?>/assets/images/wprb-logo.png';"><?php _e( 'WP Rollback', 'wp-rollback' ); ?>
 		</h1>
 
 		<p><?php echo apply_filters( 'wpr_rollback_description', sprintf( __( 'Please select which %1$s version you would like to rollback to from the releases listed below. You currently have version %2$s installed of %3$s.', 'wp-rollback' ), '<span class="type">' . ( $theme_rollback == true ? __( 'theme', 'wp-rollback' ) : __( 'plugin', 'wp-rollback' ) ) . '</span>', '<span class="current-version">' . esc_html( $args['current_version'] ) . '</span>', '<span class="rollback-name">' . esc_html( $args['rollback_name'] ) . '</span>' ) ); ?></p>
 
+		<div class="wpr-changelog"></div>
 	</div>
 
 	<?php if ( isset( $args['plugin_file'] ) && in_array( $args['plugin_file'], array_keys( $plugins ) ) ) {
 		$versions = WP_Rollback()->versions_select( 'plugin' );
-} elseif ( $theme_rollback == true && isset( $_GET['theme_file'] ) ) {
-	// theme rollback: set up our theme vars
-	$svn_tags = WP_Rollback()->get_svn_tags( 'theme', $_GET['theme_file'] );
-	$this->set_svn_versions_data( $svn_tags );
-	$this->current_version = $_GET['current_version'];
-	$versions              = WP_Rollback()->versions_select( 'theme' );
+	} elseif ( $theme_rollback == true && isset( $_GET['theme_file'] ) ) {
+		// Theme rollback: set up our theme vars
+		$svn_tags = WP_Rollback()->get_svn_tags( 'theme', $_GET['theme_file'] );
+		WP_Rollback()->set_svn_versions_data( $svn_tags );
+		$this->current_version = $_GET['current_version'];
+		$versions              = WP_Rollback()->versions_select( 'theme' );
 
-} else {
-	// Fallback check
-	wp_die( 'Oh no! We\'re missing required rollback query strings. Please contact support so we can check this bug out and squash it!', 'wp-rollback' );
-}
-	?>
+	} else {
+		// Fallback check
+		wp_die( __( 'Oh no! We\'re missing required rollback query strings. Please contact support so we can check this bug out and squash it!', 'wp-rollback' ) );
+	} ?>
 
 	<form name="check_for_rollbacks" class="rollback-form" action="<?php echo admin_url( '/index.php' ); ?>">
 		<?php
@@ -78,9 +79,7 @@ $plugins         = get_plugins();
 
 		<div id="wpr-modal-confirm" class="white-popup mfp-hide">
 			<div class="wpr-modal-inner">
-				<p class="wpr-rollback-intro"><?php
-					_e( 'Are you sure you want to perform the following rollback?', 'wp-rollback' );
-					?></p>
+				<p class="wpr-rollback-intro"><?php _e( 'Are you sure you want to perform the following rollback?', 'wp-rollback' ); ?></p>
 
 				<div class="rollback-details">
 					<table class="widefat">
@@ -90,9 +89,9 @@ $plugins         = get_plugins();
 							<td class="row-title">
 								<label for="tablecell"><?php if ( $plugin_rollback == true ) {
 										_e( 'Plugin Name:', 'wp-rollback' );
-} else {
-	_e( 'Theme Name:', 'wp-rollback' );
-} ?></label>
+									} else {
+										_e( 'Theme Name:', 'wp-rollback' );
+									} ?></label>
 							</td>
 							<td><span class="wpr-plugin-name"></span></td>
 						</tr>

--- a/includes/rollback-menu.php
+++ b/includes/rollback-menu.php
@@ -70,6 +70,7 @@ $plugins         = get_plugins();
 		// Important: We need the appropriate file to perform a rollback
 		if ( $plugin_rollback == true ) { ?>
 			<input type="hidden" name="plugin_file" value="<?php echo esc_attr( $args['plugin_file'] ); ?>">
+			<input type="hidden" name="plugin_slug" value="<?php echo esc_attr( $args['plugin_slug'] ); ?>">
 		<?php } else { ?>
 			<input type="hidden" name="theme_file" value="<?php echo esc_attr( $_GET['theme_file'] ); ?>">
 		<?php } ?>

--- a/wp-rollback.php
+++ b/wp-rollback.php
@@ -291,7 +291,7 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 			// Localize for i18n.
 			wp_localize_script( 'wp_rollback_script', 'wpr_vars', array(
 				'ajaxurl'                 => admin_url(),
-				'text_no_changelog_found' => __( 'Sorry, there wasn\'t a changelog entry found for this version.', 'wp-rollback' ),
+				'text_no_changelog_found' => sprintf( __( 'Sorry, we couldn\'t find a changelog entry found for this version. Try checking the <a href="%s" target="_blank">developer log</a> on WP.org.', 'wp-rollback' ), 'https://wordpress.org/plugins/' . $_GET['plugin_slug'] . '/#developers' ),
 				'version_missing'         => __( 'Please select a version number to perform a rollback.', 'wp-rollback' ),
 			) );
 
@@ -522,7 +522,7 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 		/**
 		 * Set Plugin Slug
 		 *
-		 * @return string|bool
+		 * @return array|bool
 		 */
 		private function set_plugin_slug() {
 
@@ -542,8 +542,6 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 			if ( ! file_exists( $plugin_file ) ) {
 				wp_die( 'Plugin you\'re referencing does not exist.' );
 			}
-
-			$plugin_data = get_plugin_data( $plugin_file, false, false );
 
 			// the plugin slug is the base directory name without the path to the main file
 			$plugin_slug = explode( '/', plugin_basename( $plugin_file ) );

--- a/wp-rollback.php
+++ b/wp-rollback.php
@@ -381,7 +381,7 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 		 *
 		 * @return null|string
 		 */
-		private function get_svn_tags( $type, $slug ) {
+		public function get_svn_tags( $type, $slug ) {
 
 			$url = $this->plugins_repo . '/' . $this->plugin_slug . '/tags/';
 
@@ -833,7 +833,7 @@ endif; // End if class_exists check
  * Example: <?php $wp_rollback = WP_Rollback(); ?>
  *
  * @since 1.0
- * @return object The one true WP Rollback Instance
+ * @return WP_Rollback object  The one true WP Rollback Instance
  */
 function WP_Rollback() {
 	return WP_Rollback::instance();

--- a/wp-rollback.php
+++ b/wp-rollback.php
@@ -290,9 +290,9 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 
 			// Localize for i18n.
 			wp_localize_script( 'wp_rollback_script', 'wpr_vars', array(
-				'ajaxurl'         => admin_url(),
+				'ajaxurl'                 => admin_url(),
 				'text_no_changelog_found' => __( 'Sorry, there wasn\'t a changelog entry found for this version.', 'wp-rollback' ),
-				'version_missing' => __( 'Please select a version number to perform a rollback.', 'wp-rollback' ),
+				'version_missing'         => __( 'Please select a version number to perform a rollback.', 'wp-rollback' ),
 			) );
 
 		}
@@ -383,7 +383,7 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 		public function get_plugin_changelog() {
 
 			// Need slug to continue.
-			if ( ! isset( $_POST['slug'] ) || empty($_POST['slug'])) {
+			if ( ! isset( $_POST['slug'] ) || empty( $_POST['slug'] ) ) {
 				return false;
 			}
 
@@ -485,15 +485,17 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 				return false;
 			}
 
-			$versions_html = '';
+			$versions_html = '<ul class="wpr-version-list">';
 
 			usort( $this->versions, 'version_compare' );
 
 			$this->versions = array_reverse( $this->versions );
 
+
 			// Loop through versions and output in a radio list.
 			foreach ( $this->versions as $version ) {
 
+				$versions_html .= '<li class="wpr-version-li">';
 				$versions_html .= '<label><input type="radio" value="' . esc_attr( $version ) . '" name="' . $type . '_version">' . $version;
 
 				// Is this the current version?
@@ -501,16 +503,20 @@ if ( ! class_exists( 'WP Rollback' ) ) : {
 					$versions_html .= '<span class="current-version">' . __( 'Installed Version', 'wp-rollback' ) . '</span>';
 				}
 
-				// Is this the current version?
+				$versions_html .= '</label>';
+
+				// View changelog link.
 				if ( 'plugin' === $type ) {
 					$versions_html .= ' <a href="#" class="wpr-changelog-link" data-version="' . $version . '">' . __( 'View Changelog', 'wp-rollback' ) . '</a>';
 				}
 
-				$versions_html .= '</label>';
+				$versions_html .= '</li>';
 
 			}
 
-			return $versions_html;
+			$versions_html .= '</ul>';
+
+			return apply_filters( 'versions_select_html', $versions_html );
 		}
 
 		/**


### PR DESCRIPTION
## PR Overview

Added functionality to view change logs for plugins. Themes don't yet have change logs so those aren't supported. 

There are a few minor issues with this functionality, but overall I feel it's ready to merge.

Resolves #7 

### Preview

![2017-07-12_15-30-36](https://user-images.githubusercontent.com/1571635/28142735-29d90b08-6717-11e7-8c11-08a59526e2c0.gif)

### Known Issues

Testing with Google Analytics by MonsterInsights:

- Change log version matching - Since the API returns the entire section I had to do some regex that isn't perfect. For instance, if you select version `5.5` no result is returned but the content appears within the API result.

![2017-07-12_15-33-26](https://user-images.githubusercontent.com/1571635/28142812-7fd006f6-6717-11e7-9384-084291a9f7af.png)

- When the change log cuts off at 5.4.8 the change log links still output. https://wordpress.org/plugins/google-analytics-for-wordpress/#developers