### PR TITLE
Add result action triggers

### DIFF
--- a/includes/rollback-action.php
+++ b/includes/rollback-action.php
@@ -8,11 +8,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$nonce   = 'upgrade-plugin_' . $this->plugin_slug;
-$url     = 'index.php?page=wp-rollback&plugin_file=' . esc_url( $args['plugin_file'] ) . 'action=upgrade-plugin';
-$plugin  = $this->plugin_slug;
-$version = $args['plugin_version'];
-
 // Theme rollback.
 if ( ! empty( $_GET['theme_file'] ) && file_exists( WP_CONTENT_DIR . '/themes/' . $_GET['theme_file'] ) ) {
 
@@ -24,13 +19,26 @@ if ( ! empty( $_GET['theme_file'] ) && file_exists( WP_CONTENT_DIR . '/themes/' 
 
 	$upgrader = new WP_Rollback_Theme_Upgrader( new Theme_Upgrader_Skin( compact( 'title', 'nonce', 'url', 'theme', 'version' ) ) );
 
-	$upgrader->rollback( $_GET['theme_file'] );
+	$result = $upgrader->rollback( $_GET['theme_file'] );
+
+	if ( !is_wp_error($result) && $result ) {do_action( 'wpr_theme_success', $_GET['theme_file'], $_GET['theme_version'] );}
+	else {do_action( 'wpr_theme_failure', $result );}
 
 } elseif ( ! empty( $_GET['plugin_file'] ) && file_exists( WP_PLUGIN_DIR . '/' . $_GET['plugin_file'] ) ) {
+	
 	// This is a plugin rollback.
+	$nonce   = 'upgrade-plugin_' . $this->plugin_slug;
+	$url     = 'index.php?page=wp-rollback&plugin_file=' . esc_url( $args['plugin_file'] ) . 'action=upgrade-plugin';
+	$plugin  = $this->plugin_slug;
+	$version = $args['plugin_version'];
+
 	$upgrader = new WP_Rollback_Plugin_Upgrader( new Plugin_Upgrader_Skin( compact( 'title', 'nonce', 'url', 'plugin', 'version' ) ) );
 
-	$upgrader->rollback( $this->plugin_file );
+	$result = $upgrader->rollback( $this->plugin_file );
+		
+	if ( !is_wp_error($result) && $result ) {do_action( 'wpr_plugin_success', $_GET['plugin_file'], $version);}
+	else {do_action( 'wpr_plugin_failure', $result );}
+	
 } else {
 	_e( 'This rollback request is missing a proper query string. Please contact support.', 'wp-rollback' );
 }


### PR DESCRIPTION
## Description
Add actions for success or failure on plugin and theme rollback actions.

## How Has This Been Tested?
Hooked a simple logging function in an mu-plugin file to the action hook and ran a rollback.
Test run on Local by Flywheel. Should not affect other areas of code.

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [/] My code is tested.
- [/] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.