### PR TITLE
Add additional `is_string` check to prevent PHP error #86

### DIFF
--- a/wp-rollback.php
+++ b/wp-rollback.php
@@ -480,7 +480,7 @@ if ( ! class_exists( 'WP_Rollback' ) ) :
             $plugin_data = apply_filters( 'wpr_plugin_data', $plugin_data );
 
             // If plugin is missing package data do not output Rollback option.
-            if ( ! isset( $plugin_data['package'] ) ||
+            if ( ! isset( $plugin_data['package'] ) || ! is_string( $plugin_data['package'] ) ||
                  ( strpos( $plugin_data['package'], 'downloads.wordpress.org' ) === false ) ) {
                 return $actions;
             }


### PR DESCRIPTION
## Description
<!-- Please describe your changes -->

Add `is_string()` check to prevent PHP notices

Resolves #86 